### PR TITLE
Add libopenblas to install.sh

### DIFF
--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -3,6 +3,6 @@ git clone https://github.com/burkeob/COVID-MCS
 cd COVID-MCS
 conda install -c conda-forge paramtools pandas rpy2
 conda install -c r r r-dplyr r-lubridate
-conda install -c conda-forge r-quadprog
+conda install -c conda-forge r-quadprog libopenblas
 
 pip install -e .


### PR DESCRIPTION
@burkeob this should resolve https://github.com/compute-tooling/compute-studio-publish/pull/55

I tested this locally by building the environment for COVID-MCS locally and then adding `libopenblas` to the install commands.

```
$ docker run -it burkeob_covidmcs_tasks:test /bin/bash
(base) root@3f6ad5fa5df9:/home# conda install libopenblas -c conda-forge
Collecting package metadata (current_repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /opt/conda

  added / updated specs:
    - libopenblas


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    libopenblas-0.3.7          |       h5ec1e0e_6         7.6 MB  conda-forge
    ------------------------------------------------------------
                                           Total:         7.6 MB

The following NEW packages will be INSTALLED:

  libopenblas        conda-forge/linux-64::libopenblas-0.3.7-h5ec1e0e_6


Proceed ([y]/n)? y


Downloading and Extracting Packages
libopenblas-0.3.7    | 7.6 MB    | ################################################################################################################################################### | 100% 
Preparing transaction: done
Verifying transaction: done
Executing transaction: done
(base) root@3f6ad5fa5df9:/home# py.test test_functions.py -v
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.7.7, pytest-5.4.3, py-1.8.1, pluggy-0.13.1 -- /opt/conda/bin/python
cachedir: .pytest_cache
rootdir: /home
collected 5 items                                                                                                                                                                            

test_functions.py::TestFunctions1::test_all_data_specified PASSED                                                                                                                      [ 20%]
test_functions.py::TestFunctions1::test_get_version PASSED                                                                                                                             [ 40%]
test_functions.py::TestFunctions1::test_get_inputs PASSED                                                                                                                              [ 60%]
test_functions.py::TestFunctions1::test_validate_inputs PASSED                                                                                                                         [ 80%]
test_functions.py::TestFunctions1::test_run_model PASSED                                                                                                                               [100%]

===================================================================================== 5 passed in 10.53s =====================================================================================
R[write to console]: Warning message:

R[write to console]: package ‘quadprog’ was built under R version 3.6.2 

(base) root@3f6ad5fa5df9:/home# 

```